### PR TITLE
Log network difficulty

### DIFF
--- a/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
@@ -189,7 +189,7 @@ namespace Miningcore.Blockchain.Ethereum
                 // telemetry
                 PublishTelemetry(TelemetryCategory.Share, clock.UtcNow - tsRequest.Timestamp.UtcDateTime, true);
 
-                logger.Info(() => $"[{client.ConnectionId}] Share accepted: D={Math.Round(share.Difficulty / EthereumConstants.Pow2x32, 3)}");
+                logger.Info(() => $"[{client.ConnectionId}] Share accepted: D={Math.Round(share.Difficulty / EthereumConstants.Pow2x32, 3)} ND={Math.Round(share.NetworkDifficulty / EthereumConstants.Pow2x32, 3)}");
                 await EnsureInitialWorkSent(client);
 
                 // update pool stats


### PR DESCRIPTION
From the logs, we could see a variation in share Difficulty. Like 0.087, 0.111, 0.03 etc.
Considering D=0.087 from log, share difficulty would be 373662155 (Hash/Solution).
In internet, we can see that network difficulty might be some Terra H/S. 
Hence I am still dividing the networkDifficulty by 2^32. Once we see the log, we will have an idea on the value of n/w diff.

This change needs to be tested.