### PR TITLE
CRBN-216 Pool should expose payout calculation data

### DIFF
--- a/src/Miningcore/Api/Responses/GetPoolsResponse.cs
+++ b/src/Miningcore/Api/Responses/GetPoolsResponse.cs
@@ -43,6 +43,7 @@ namespace Miningcore.Api.Responses
         public bool Enabled { get; set; }
         public decimal MinimumPayment { get; set; } // in pool-base-currency (ie. Bitcoin, not Satoshis)
         public string PayoutScheme { get; set; }
+        public decimal HashValue { get; set; } // value of a hash in pool-base-currency, if using PPS payouts
         public JToken PayoutSchemeConfig { get; set; }
 
         [JsonExtensionData]

--- a/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
@@ -219,7 +219,7 @@ namespace Miningcore.Blockchain.Ethereum
                 TelemetryClient tc = TelemetryUtil.GetTelemetryClient();
                 if(null != tc)
                 {
-                    tc.GetMetric("REJECTED_SHARES").TrackValue(difficulty);
+                    tc.GetMetric("REJECTED_SHARES").TrackValue(difficulty, ex.Message);
                 }
 
                 // update client stats

--- a/src/Miningcore/Configuration/ClusterConfig.cs
+++ b/src/Miningcore/Configuration/ClusterConfig.cs
@@ -558,7 +558,17 @@ namespace Miningcore.Configuration
         public bool Enabled { get; set; }
         public decimal MinimumPayment { get; set; } // in pool-base-currency (ie. Bitcoin, not Satoshis)
         public PayoutScheme PayoutScheme { get; set; }
+
+        /// <summary>
+        /// When predicting block frequency for PPS payouts, set a guardrail on the maximum if the pool size is very small.
+        /// </summary>
         public int MaxBlockFrequency { get; set; }
+
+        /// <summary>
+        /// Value of a hash in Eth, based on PPS calculation
+        /// </summary>
+        public decimal HashValue { get; set; }
+        
         public JToken PayoutSchemeConfig { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Expose the latest Eth-per-hash calculation from the PPS algorithm via the pool's API.

Also found & fixed a bug in the overall PPS Payout loop where we were not tallying up all the shares before paying out some users.
this means that shares mined in earlier "pages" may be rewarded multiple times.