### PR TITLE
Fixing dimensional metric for Rejected Shares

### DIFF
--- a/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
@@ -219,7 +219,7 @@ namespace Miningcore.Blockchain.Ethereum
                 TelemetryClient tc = TelemetryUtil.GetTelemetryClient();
                 if(null != tc)
                 {
-                    tc.GetMetric("REJECTED_SHARES").TrackValue(difficulty, ex.Message);
+                    tc.GetMetric("REJECTED_SHARES", "Cause").TrackValue(difficulty, ex.Message);
                 }
 
                 // update client stats


### PR DESCRIPTION
Fixing the 1-dimensional metric to track rejected shares.

The number of arguments to TrackValue (dimension values)
must match the number of dimensions specified while GetMetric.