### PR TITLE
don't deduct more fees if pending balance is already above payout minimum

### DIFF
--- a/src/Miningcore/Blockchain/Ethereum/EthereumPayoutHandler.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPayoutHandler.cs
@@ -391,6 +391,10 @@ namespace Miningcore.Blockchain.Ethereum
                 var txCost = gasAmount * gasFee;
 
                 var payoutThreshold = poolConfig.PaymentProcessing.MinimumPayment;
+                if(0 == payoutThreshold)
+                {
+                    throw new Exception($"Misconfiguration in payments. MinimumPayment is set to {payoutThreshold}");
+                }
 
                 var amountRatio = amount / payoutThreshold;
                 

--- a/src/Miningcore/Blockchain/Ethereum/EthereumPayoutHandler.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPayoutHandler.cs
@@ -391,7 +391,7 @@ namespace Miningcore.Blockchain.Ethereum
                 var txCost = gasAmount * gasFee;
 
                 var payoutThreshold = poolConfig.PaymentProcessing.MinimumPayment;
-                if(0 == payoutThreshold)
+                if(0 <= payoutThreshold)
                 {
                     throw new Exception($"Misconfiguration in payments. MinimumPayment is set to {payoutThreshold}");
                 }

--- a/src/Miningcore/Persistence/Repositories/IBalanceRepository.cs
+++ b/src/Miningcore/Persistence/Repositories/IBalanceRepository.cs
@@ -28,6 +28,8 @@ namespace Miningcore.Persistence.Repositories
     public interface IBalanceRepository
     {
         Task<int> AddAmountAsync(IDbConnection con, IDbTransaction tx, string poolId, string address, decimal amount, string usage);
+
+        Task<int> AddAmountAsyncDeductingTxFee(IDbConnection con, IDbTransaction tx, string poolId, string address, decimal amount, string usage, decimal deduction, decimal threshold);
         Task<decimal> GetBalanceAsync(IDbConnection con, string poolId, string address);
         Task<decimal> GetBalanceAsync(IDbConnection con, IDbTransaction tx, string poolId, string address);
 


### PR DESCRIPTION
the tx Fees are based on a single transaction equaling the payout minimum.
if pending balance is already over payout minimum, then the txFee has already been paid.  No need to deduct more.

Put the deduction logic down in the balanceRepo in order to save the extra DB query.