### PR TITLE
CRBN-255: Streamline the Pool's Data API

### DIFF
--- a/src/Miningcore/Api/Extensions/MiningPoolExtensions.cs
+++ b/src/Miningcore/Api/Extensions/MiningPoolExtensions.cs
@@ -16,8 +16,12 @@ namespace Miningcore.Api.Extensions
         {
             var poolInfo = mapper.Map<PoolInfo>(poolConfig);
 
-            poolInfo.PoolStats = mapper.Map<PoolStats>(stats);
-            poolInfo.NetworkStats = pool?.NetworkStats ?? mapper.Map<BlockchainStats>(stats);
+            // map stats if it is not null
+            if (null != stats)
+            {
+                poolInfo.PoolStats = mapper.Map<PoolStats>(stats);
+                poolInfo.NetworkStats = pool?.NetworkStats ?? mapper.Map<BlockchainStats>(stats);
+            }
 
             // pool wallet link
             var addressInfobaseUrl = poolConfig.Template.ExplorerAccountLink;


### PR DESCRIPTION
cloud-payouts only uses "minPayout" and "hashValue" from this API (/api/pools/%s)
cloud-wallet and control-performance do not use this API (they only use /api/pools/%s/miners/%s)