### PR TITLE
earnings estimation should include tx fee deductions, if they are enabled

### DIFF
--- a/src/Miningcore/Payments/PaymentSchemes/PPSPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPSPaymentScheme.cs
@@ -70,7 +70,7 @@ namespace Miningcore.Payments.PaymentSchemes
             var shares = new Dictionary<string, double>();
             var rewards = new Dictionary<string, decimal>();
             var paidUntil = DateTime.UtcNow;
-            var shareCutOffDate = await CalculateRewards(poolConfig, shares, rewards, blockReward, paidUntil);
+            var shareCutOffDate = await CalculateRewards(poolConfig, payoutHandler, shares, rewards, blockReward, paidUntil);
 
             // update balances
             foreach(var address in rewards.Keys)
@@ -142,6 +142,7 @@ namespace Miningcore.Payments.PaymentSchemes
 
         private async Task<DateTime?> CalculateRewards(
             PoolConfig poolConfig,
+            IPayoutHandler payoutHandler,
             Dictionary<string, double> shares,
             Dictionary<string, decimal> rewards,
             decimal blockData,
@@ -237,6 +238,12 @@ namespace Miningcore.Payments.PaymentSchemes
             {
                 valPerMHash = (blockData / (Decimal) sumDifficulty) * 1000000;  // count MegaHashes instead of hashes.
             }
+
+            if(payoutHandler.MinersPayTxFees())
+            {
+                valPerMHash -= (payoutHandler.GetTransactionDeduction(valPerMHash));
+            }
+
             poolConfig.PaymentProcessing.HashValue = valPerMHash;
 
             // Update the hashvalue in the database

--- a/src/Miningcore/Payments/PayoutHandlerBase.cs
+++ b/src/Miningcore/Payments/PayoutHandlerBase.cs
@@ -179,7 +179,7 @@ namespace Miningcore.Payments
         public string FormatAmount(decimal amount)
         {
             var coin = poolConfig.Template.As<CoinTemplate>();
-            return $"{amount:0.#######} {coin.Symbol}";
+            return $"{amount:0.#########} {coin.Symbol}";
         }
 
         protected virtual void NotifyPayoutSuccess(string poolId, Balance[] balances, string[] txHashes, decimal? txFee)


### PR DESCRIPTION
make the same deduction from the hashValue

also increase the FormatAmount decimal precision so that the logs get a little more detail